### PR TITLE
fix: Sass deprecations (slash as division)

### DIFF
--- a/dist/scss/abstracts/_functions.scss
+++ b/dist/scss/abstracts/_functions.scss
@@ -24,7 +24,7 @@
   $g: green($color);
   $b: blue($color);
 
-  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+  $yiq: calc((($r * 299) + ($g * 587) + ($b * 114)) / 1000);
   // stylelint-enable
 
   @if ($yiq >= $kbc-yiq-contrasted-threshold) {
@@ -40,7 +40,7 @@
   $g: green($color);
   $b: blue($color);
 
-  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+  $yiq: calc((($r * 299) + ($g * 587) + ($b * 114)) / 1000);
   // stylelint-enable
 
   @if ($yiq >= $kbc-yiq-contrasted-threshold) {

--- a/dist/scss/abstracts/_mixins.scss
+++ b/dist/scss/abstracts/_mixins.scss
@@ -5,7 +5,7 @@
 // Shadow
 @mixin button-shadow($depth, $shadow-color) {
   box-shadow: calculate-box-shadow($depth, $shadow-color),
-    2px #{$depth / 2}px 4px $kbc-gray-500, 0 -1px #{$depth / 2}px $kbc-gray-500;
+    2px #{calc($depth / 2)}px 4px $kbc-gray-500, 0 -1px #{calc($depth / 2)}px $kbc-gray-500;
 }
 
 // Button sizes
@@ -51,7 +51,7 @@
 
   font-size: $font-size;
   line-height: $line-height;
-  margin-bottom: 0.25rem + $depth / 16;
+  margin-bottom: 0.25rem + calc($depth / 16);
   margin-left: 0.25rem;
   margin-right: 0.25rem;
   margin-top: 0.25rem;
@@ -110,7 +110,7 @@
 
   font-size: $font-size;
   line-height: $line-height;
-  margin-bottom: ($after-border-width + 0.25rem + $depth / 16);
+  margin-bottom: ($after-border-width + 0.25rem + calc($depth / 16));
   margin-left: ($after-border-width + 0.25rem);
   margin-right: ($after-border-width + 0.25rem);
   margin-top: ($after-border-width + 0.25rem);

--- a/src/scss/abstracts/_functions.scss
+++ b/src/scss/abstracts/_functions.scss
@@ -24,7 +24,7 @@
   $g: green($color);
   $b: blue($color);
 
-  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+  $yiq: calc((($r * 299) + ($g * 587) + ($b * 114)) / 1000);
   // stylelint-enable
 
   @if ($yiq >= $kbc-yiq-contrasted-threshold) {
@@ -40,7 +40,7 @@
   $g: green($color);
   $b: blue($color);
 
-  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+  $yiq: calc((($r * 299) + ($g * 587) + ($b * 114)) / 1000);
   // stylelint-enable
 
   @if ($yiq >= $kbc-yiq-contrasted-threshold) {

--- a/src/scss/abstracts/_mixins.scss
+++ b/src/scss/abstracts/_mixins.scss
@@ -5,7 +5,7 @@
 // Shadow
 @mixin button-shadow($depth, $shadow-color) {
   box-shadow: calculate-box-shadow($depth, $shadow-color),
-    2px #{$depth / 2}px 4px $kbc-gray-500, 0 -1px #{$depth / 2}px $kbc-gray-500;
+    2px #{calc($depth / 2)}px 4px $kbc-gray-500, 0 -1px #{calc($depth / 2)}px $kbc-gray-500;
 }
 
 // Button sizes
@@ -51,7 +51,7 @@
 
   font-size: $font-size;
   line-height: $line-height;
-  margin-bottom: 0.25rem + $depth / 16;
+  margin-bottom: 0.25rem + calc($depth / 16);
   margin-left: 0.25rem;
   margin-right: 0.25rem;
   margin-top: 0.25rem;
@@ -110,7 +110,7 @@
 
   font-size: $font-size;
   line-height: $line-height;
-  margin-bottom: ($after-border-width + 0.25rem + $depth / 16);
+  margin-bottom: ($after-border-width + 0.25rem + calc($depth / 16));
   margin-left: ($after-border-width + 0.25rem);
   margin-right: ($after-border-width + 0.25rem);
   margin-top: ($after-border-width + 0.25rem);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

While processing SCSS files when building an application, you get deprecation warnings about slash characters used for division operations.

## What is the new behavior?

Same output without the deprecation warnings.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Sass documentation: https://sass-lang.com/documentation/breaking-changes/slash-div/